### PR TITLE
Set the cached children atomically

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 * When parsing from an InputStream and a multibyte character happened to straddle a buffer boundary, the stream would not be completely read. [#2353](https://github.com/jhy/jsoup/issues/2353).
 * In `NodeTraversor`, if a last child element was removed during the `head()` call, the parent would be visited twice. [#2355](https://github.com/jhy/jsoup/issues/2355).
 * Cloning an Element that has an Attributes object would add an empty internal user-data attribute to that clone, which would cause unexpected results for `Attributes#size()` and `Attributes#isEmpty()`. [#2356](https://github.com/jhy/jsoup/issues/2356)
+* In a multithreaded application where multiple threads are calling `Element#children()` on the same element concurrently, a race condition could happen when the method was generating the internal child element cache (a filtered view of its child nodes). Since concurrent reads of DOM objects should be threadsafe without external synchronization, this method has been updated to execute atomically. [#2366](https://github.com/jhy/jsoup/issues/2366)
 
 ## 1.21.1 (2025-Jun-23)
 

--- a/src/main/java/org/jsoup/nodes/Element.java
+++ b/src/main/java/org/jsoup/nodes/Element.java
@@ -391,12 +391,15 @@ public class Element extends Node implements Iterable<Element> {
      */
     List<Element> childElementsList() {
         if (childNodeSize() == 0) return EmptyChildren; // short circuit creating empty
-        List<Element> children = cachedChildren();
-        if (children == null) {
-            children = filterNodes(Element.class);
-            stashChildren(children);
+        // set atomically, so works in multi-thread. Calling methods look like reads, so should be thread-safe
+        synchronized (childNodes) { // sync vs re-entrant lock, to save another field
+            List<Element> children = cachedChildren();
+            if (children == null) {
+                children = filterNodes(Element.class);
+                stashChildren(children);
+            }
+            return children;
         }
-        return children;
     }
 
     private static final String childElsKey = "jsoup.childEls";


### PR DESCRIPTION
If a multithreaded app under significant GC pressure called Element#children(), race conditions could occur getting and setting the user data.

Need to revisit test, doesn't always fire unless system is constrained. Probably needs deeper iterations or more GC. The supplied JMH always failed previously, and always passes now.

Fixes #2366