### PR TITLE
Added option to use re2j for CSS query regexes (#2407)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,16 @@
 ## 1.22.1 (PENDING)
 
 ### Improvements
+* Added support for using the re2j regular expression engine for CSS selectors, which ensures linear-time performance for regex evaluation. This enables safe handling of arbitrary user-supplied query regexes. To enable, add the `com.google.re2j` dependency to your classpath, e.g.:
+```xml
+  <dependency>
+    <groupId>com.google.re2j</groupId>
+    <artifactId>re2j</artifactId>
+    <version>1.8</version>
+  </dependency>
+ ```
+  (If you already have that dependency in your classpath, but you want to keep using the Java regex engine, you can disable re2j via `System.setProperty("jsoup.useRe2j", "false")`.) [#2407](https://github.com/jhy/jsoup/pull/2407)
+
 * Added an instance method `Parser#unescape(String, boolean)` that unescapes HTML entities using the parser’s configuration (e.g. to support error tracking), complementing the existing static utility `Parser.unescapeEntities(String, boolean)`. [#2396](https://github.com/jhy/jsoup/pull/2396)
 * Build: added CI coverage for JDK 25 [#2403](https://github.com/jhy/jsoup/pull/2403)
 * Build: added a CI fuzzer for contextual fragment parsing (in addition to existing full body HTML and XML fuzzers). [oss-fuzz #14041](https://github.com/google/oss-fuzz/pull/14041)

--- a/pom.xml
+++ b/pom.xml
@@ -544,6 +544,15 @@
       <version>1.0.0</version>
       <scope>provided</scope>
     </dependency>
+
+    <dependency>
+      <!-- re2j; linear time regex, with 3-clause BSD license -->
+      <groupId>com.google.re2j</groupId>
+      <artifactId>re2j</artifactId>
+      <version>1.8</version>
+      <optional>true</optional>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 
   <dependencyManagement>

--- a/src/main/java/org/jsoup/helper/Re2jRegex.java
+++ b/src/main/java/org/jsoup/helper/Re2jRegex.java
@@ -1,0 +1,46 @@
+package org.jsoup.helper;
+
+/**
+ re2j-backed Regex implementation; must only be touched when re2j is on the classpath.
+ */
+final class Re2jRegex extends Regex {
+    private static final java.util.regex.Pattern unused = java.util.regex.Pattern.compile("");
+
+    private final com.google.re2j.Pattern re2jPattern;
+
+    private Re2jRegex(com.google.re2j.Pattern re2jPattern) {
+        super(unused);
+        this.re2jPattern = re2jPattern;
+    }
+
+    public static Regex compile(String regex) {
+        try {
+            return new Re2jRegex(com.google.re2j.Pattern.compile(regex));
+        } catch (RuntimeException e) {
+            throw new ValidationException("Pattern syntax error: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public Matcher matcher(CharSequence input) {
+        return new Re2jMatcher(re2jPattern.matcher(input));
+    }
+
+    @Override
+    public String toString() {
+        return re2jPattern.toString();
+    }
+
+    private static final class Re2jMatcher implements Matcher {
+        private final com.google.re2j.Matcher delegate;
+
+        Re2jMatcher(com.google.re2j.Matcher delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public boolean find() {
+            return delegate.find();
+        }
+    }
+}

--- a/src/main/java/org/jsoup/helper/Regex.java
+++ b/src/main/java/org/jsoup/helper/Regex.java
@@ -1,0 +1,111 @@
+package org.jsoup.helper;
+
+import org.jsoup.internal.SharedConstants;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+/**
+ A regular expression abstraction. Allows jsoup to optionally use the re2j regular expression engine (linear time)
+ instead of the JDK's backtracking regex implementation.
+
+ <p>If the {@code com.google.re2j} library is found on the classpath, by default it will be used. You can override this
+ by setting {@code -Djsoup.useRe2j=false} to explicitly disable, and use the JDK regex engine.</p>
+
+ <p>(Currently this a simplified implementation for jsoup's specific use; can extend as required.)</p>
+ */
+public class Regex {
+    private static final boolean hasRe2j = hasRe2j();
+
+    private final Pattern jdkPattern;
+
+    Regex(Pattern jdkPattern) {
+        this.jdkPattern = jdkPattern;
+    }
+
+    /**
+     Compile a regex, using re2j if enabled and available; otherwise JDK regex.
+
+     @param regex the regex to compile
+     @return the compiled regex
+     @throws ValidationException if the regex is invalid
+     */
+    public static Regex compile(String regex) {
+        if (hasRe2j && wantsRe2j()) {
+            return Re2jRegex.compile(regex);
+        }
+
+        try {
+            return new Regex(Pattern.compile(regex));
+        } catch (PatternSyntaxException e) {
+            throw new ValidationException("Pattern syntax error: " + e.getMessage());
+        }
+    }
+
+    /** Wraps an existing JDK Pattern (for API compat); doesn't switch */
+    public static Regex fromPattern(Pattern pattern) {
+        return new Regex(pattern);
+    }
+
+    static boolean wantsRe2j() {
+        return Boolean.parseBoolean(System.getProperty(SharedConstants.UseRe2j, "true"));
+    }
+
+    static void wantsRe2j(boolean use) {
+        System.setProperty(SharedConstants.UseRe2j, Boolean.toString(use));
+    }
+
+    static boolean hasRe2j() {
+        try {
+            Class<?> re2 = Class.forName("com.google.re2j.Pattern", false, Regex.class.getClassLoader()); // check if re2j is in classpath
+            try {
+                // if it is, and we are on JVM9+, we need to dork around with modules, because re2j doesn't publish a module name.
+                // done via reflection so we can still run on JVM 8.
+                // todo remove if re2j publishes as a module
+                Class<?> moduleCls = Class.forName("java.lang.Module");
+                Method getModule = Class.class.getMethod("getModule");
+                Object jsoupMod = getModule.invoke(Regex.class);
+                Object re2Mod = getModule.invoke(re2);
+                boolean reads = (boolean) moduleCls.getMethod("canRead", moduleCls).invoke(jsoupMod, re2Mod);
+                if (!reads) moduleCls.getMethod("addReads", moduleCls).invoke(jsoupMod, re2Mod);
+            } catch (ClassNotFoundException ignore) {
+                // jvm8 - no Module class; so we can use as-is
+            }
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false; // no re2j
+        } catch (ReflectiveOperationException e) {
+            // unexpectedly couldn’t wire modules on 9+; return false to avoid IllegalAccessError later
+            System.err.println("Warning: (bug? please report) couldn't access re2j from jsoup due to modules: " + e);
+            return false;
+        }
+    }
+
+    public Matcher matcher(CharSequence input) {
+        return new JdkMatcher(jdkPattern.matcher(input));
+    }
+
+    @Override
+    public String toString() {
+        return jdkPattern.toString();
+    }
+
+    public interface Matcher {
+        boolean find();
+    }
+
+    private static final class JdkMatcher implements Matcher {
+        private final java.util.regex.Matcher delegate;
+
+        JdkMatcher(java.util.regex.Matcher delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public boolean find() {
+            return delegate.find();
+        }
+    }
+}

--- a/src/main/java/org/jsoup/internal/SharedConstants.java
+++ b/src/main/java/org/jsoup/internal/SharedConstants.java
@@ -21,5 +21,7 @@ public final class SharedConstants {
 
     public static final String UseHttpClient = "jsoup.useHttpClient";
 
+    public static final String UseRe2j = "jsoup.useRe2j"; // enables use of the re2j regular expression engine when true and it's on the classpath
+
     private SharedConstants() {}
 }

--- a/src/main/java/org/jsoup/nodes/Element.java
+++ b/src/main/java/org/jsoup/nodes/Element.java
@@ -3,6 +3,7 @@ package org.jsoup.nodes;
 import org.jsoup.helper.Validate;
 import org.jsoup.internal.Normalizer;
 import org.jsoup.internal.QuietAppendable;
+import org.jsoup.helper.Regex;
 import org.jsoup.internal.StringUtil;
 import org.jsoup.parser.ParseSettings;
 import org.jsoup.parser.Parser;
@@ -1404,7 +1405,6 @@ public class Element extends Node implements Iterable<Element> {
      */
     public Elements getElementsByAttributeValueMatching(String key, Pattern pattern) {
         return Collector.collect(new Evaluator.AttributeWithValueMatching(key, pattern), this);
-
     }
 
     /**
@@ -1414,13 +1414,13 @@ public class Element extends Node implements Iterable<Element> {
      * @return elements that have attributes matching this regular expression
      */
     public Elements getElementsByAttributeValueMatching(String key, String regex) {
-        Pattern pattern;
+        Regex pattern;
         try {
-            pattern = Pattern.compile(regex);
+            pattern = Regex.compile(regex);
         } catch (PatternSyntaxException e) {
             throw new IllegalArgumentException("Pattern syntax error: " + regex, e);
         }
-        return getElementsByAttributeValueMatching(key, pattern);
+        return Collector.collect(new Evaluator.AttributeWithValueMatching(key, pattern), this);
     }
 
     /**
@@ -1489,13 +1489,13 @@ public class Element extends Node implements Iterable<Element> {
      * @see Element#text()
      */
     public Elements getElementsMatchingText(String regex) {
-        Pattern pattern;
+        Regex pattern;
         try {
-            pattern = Pattern.compile(regex);
+            pattern = Regex.compile(regex);
         } catch (PatternSyntaxException e) {
             throw new IllegalArgumentException("Pattern syntax error: " + regex, e);
         }
-        return getElementsMatchingText(pattern);
+        return Collector.collect(new Evaluator.Matches(pattern), this);
     }
 
     /**
@@ -1515,13 +1515,13 @@ public class Element extends Node implements Iterable<Element> {
      * @see Element#ownText()
      */
     public Elements getElementsMatchingOwnText(String regex) {
-        Pattern pattern;
+        Regex pattern;
         try {
-            pattern = Pattern.compile(regex);
+            pattern = Regex.compile(regex);
         } catch (PatternSyntaxException e) {
             throw new IllegalArgumentException("Pattern syntax error: " + regex, e);
         }
-        return getElementsMatchingOwnText(pattern);
+        return Collector.collect(new Evaluator.MatchesOwn(pattern), this);
     }
 
     /**

--- a/src/main/java/org/jsoup/select/Evaluator.java
+++ b/src/main/java/org/jsoup/select/Evaluator.java
@@ -11,10 +11,10 @@ import org.jsoup.nodes.PseudoTextElement;
 import org.jsoup.nodes.TextNode;
 import org.jsoup.nodes.XmlDeclaration;
 import org.jsoup.parser.ParseSettings;
+import org.jsoup.helper.Regex;
 
 import java.util.List;
 import java.util.function.Predicate;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static org.jsoup.internal.Normalizer.lowerCase;
@@ -385,11 +385,15 @@ public abstract class Evaluator {
      */
     public static final class AttributeWithValueMatching extends Evaluator {
         final String key;
-        final Pattern pattern;
+        final Regex pattern;
 
-        public AttributeWithValueMatching(String key, Pattern pattern) {
+        public AttributeWithValueMatching(String key, Regex pattern) {
             this.key = normalize(key);
             this.pattern = pattern;
+        }
+
+        public AttributeWithValueMatching(String key, Pattern pattern) {
+            this(key, Regex.fromPattern(pattern)); // api compat
         }
 
         @Override
@@ -924,16 +928,19 @@ public abstract class Evaluator {
      * Evaluator for matching Element (and its descendants) text with regex
      */
     public static final class Matches extends Evaluator {
-        private final Pattern pattern;
+        private final Regex pattern;
+
+        public Matches(Regex pattern) {
+            this.pattern = pattern;
+        }
 
         public Matches(Pattern pattern) {
-            this.pattern = pattern;
+            this(Regex.fromPattern(pattern));
         }
 
         @Override
         public boolean matches(Element root, Element element) {
-            Matcher m = pattern.matcher(element.text());
-            return m.find();
+            return pattern.matcher(element.text()).find();
         }
 
         @Override protected int cost() {
@@ -950,16 +957,19 @@ public abstract class Evaluator {
      * Evaluator for matching Element's own text with regex
      */
     public static final class MatchesOwn extends Evaluator {
-        private final Pattern pattern;
+        private final Regex pattern;
+
+        public MatchesOwn(Regex pattern) {
+            this.pattern = pattern;
+        }
 
         public MatchesOwn(Pattern pattern) {
-            this.pattern = pattern;
+            this(Regex.fromPattern(pattern));
         }
 
         @Override
         public boolean matches(Element root, Element element) {
-            Matcher m = pattern.matcher(element.ownText());
-            return m.find();
+            return pattern.matcher(element.ownText()).find();
         }
 
         @Override protected int cost() {
@@ -977,16 +987,19 @@ public abstract class Evaluator {
      * @since 1.15.1.
      */
     public static final class MatchesWholeText extends Evaluator {
-        private final Pattern pattern;
+        private final Regex pattern;
+
+        public MatchesWholeText(Regex pattern) {
+            this.pattern = pattern;
+        }
 
         public MatchesWholeText(Pattern pattern) {
-            this.pattern = pattern;
+            this.pattern = Regex.fromPattern(pattern);
         }
 
         @Override
         public boolean matches(Element root, Element element) {
-            Matcher m = pattern.matcher(element.wholeText());
-            return m.find();
+            return pattern.matcher(element.wholeText()).find();
         }
 
         @Override protected int cost() {
@@ -1004,15 +1017,19 @@ public abstract class Evaluator {
      * @since 1.15.1.
      */
     public static final class MatchesWholeOwnText extends Evaluator {
-        private final Pattern pattern;
+        private final Regex pattern;
+
+        public MatchesWholeOwnText(Regex pattern) {
+            this.pattern = pattern;
+        }
 
         public MatchesWholeOwnText(Pattern pattern) {
-            this.pattern = pattern;
+            this(Regex.fromPattern(pattern));
         }
 
         @Override
         public boolean matches(Element root, Element element) {
-            Matcher m = pattern.matcher(element.wholeOwnText());
+            Regex.Matcher m = pattern.matcher(element.wholeOwnText());
             return m.find();
         }
 

--- a/src/main/java/org/jsoup/select/NodeEvaluator.java
+++ b/src/main/java/org/jsoup/select/NodeEvaluator.java
@@ -4,8 +4,7 @@ import org.jsoup.internal.StringUtil;
 import org.jsoup.nodes.Element;
 import org.jsoup.nodes.LeafNode;
 import org.jsoup.nodes.Node;
-
-import java.util.regex.Pattern;
+import org.jsoup.helper.Regex;
 
 import static org.jsoup.internal.Normalizer.lowerCase;
 import static org.jsoup.internal.StringUtil.normaliseWhitespace;
@@ -98,9 +97,9 @@ abstract class NodeEvaluator extends Evaluator {
     }
 
     static class MatchesValue extends NodeEvaluator {
-        private final Pattern pattern;
+        private final Regex pattern;
 
-        protected MatchesValue(Pattern pattern) {
+        protected MatchesValue(Regex pattern) {
             this.pattern = pattern;
         }
 

--- a/src/main/java/org/jsoup/select/QueryParser.java
+++ b/src/main/java/org/jsoup/select/QueryParser.java
@@ -1,5 +1,6 @@
 package org.jsoup.select;
 
+import org.jsoup.helper.Regex;
 import org.jsoup.internal.StringUtil;
 import org.jsoup.helper.Validate;
 import org.jsoup.nodes.CDataNode;
@@ -367,7 +368,7 @@ public class QueryParser implements AutoCloseable {
             else if (cq.matchChomp("*="))
                 eval = new Evaluator.AttributeWithValueContaining(key, cq.remainder());
             else if (cq.matchChomp("~="))
-                eval = new Evaluator.AttributeWithValueMatching(key, Pattern.compile(cq.remainder()));
+                eval = new Evaluator.AttributeWithValueMatching(key, Regex.compile(cq.remainder()));
             else
                 throw new Selector.SelectorParseException(
                     "Could not parse attribute query '%s': unexpected token at '%s'", query, cq.remainder());
@@ -472,7 +473,7 @@ public class QueryParser implements AutoCloseable {
         String query = own ? ":matchesOwn" : ":matches";
         String regex = consumeParens(); // don't unescape, as regex bits will be escaped
         Validate.notEmpty(regex, query + "(regex) query must not be empty");
-        Pattern pattern = Pattern.compile(regex);
+        Regex pattern = Regex.compile(regex);
 
         if (inNodeContext)
             return new NodeEvaluator.MatchesValue(pattern);
@@ -488,9 +489,10 @@ public class QueryParser implements AutoCloseable {
         String regex = consumeParens(); // don't unescape, as regex bits will be escaped
         Validate.notEmpty(regex, query + "(regex) query must not be empty");
 
+        Regex pattern = Regex.compile(regex);
         return own
-            ? new Evaluator.MatchesWholeOwnText(Pattern.compile(regex))
-            : new Evaluator.MatchesWholeText(Pattern.compile(regex));
+            ? new Evaluator.MatchesWholeOwnText(pattern)
+            : new Evaluator.MatchesWholeText(pattern);
     }
 
     // :not(selector)

--- a/src/test/java/org/jsoup/helper/RegexTest.java
+++ b/src/test/java/org/jsoup/helper/RegexTest.java
@@ -1,0 +1,74 @@
+package org.jsoup.helper;
+
+import org.jsoup.select.QueryParser;
+import org.jsoup.select.Selector;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class RegexTest {
+
+    private boolean originalUseRe2j; // track original setting
+
+    @BeforeEach
+    void setUp() {
+        originalUseRe2j = Regex.wantsRe2j();
+    }
+
+    @AfterEach
+    void tearDown() {
+        Regex.wantsRe2j(originalUseRe2j); // restore original setting
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void testRegexDelegates(boolean useRe2j) {
+        Regex.wantsRe2j(useRe2j);
+        String pattern = "(\\d+)";
+        String input = "12345";
+
+        Regex regex = Regex.compile(pattern);
+        Regex.Matcher matcher = regex.matcher(input);
+        assertTrue(matcher.find());
+    }
+
+    @Test
+    void jdkSupportsBackreferenceMatches() {
+        Regex.wantsRe2j(false);
+        String pattern = "(\\w+)\\s+\\1"; // backreference to group 1
+        String input = "hello hello";
+
+        Regex regex = Regex.compile(pattern);
+        Regex.Matcher matcher = regex.matcher(input);
+        assertTrue(matcher.find());
+    }
+
+    @Test
+    void re2jRejectsBackreferenceThrows() {
+        Regex.wantsRe2j(true);
+        String pattern = "(\\w+)\\s+\\1"; // backreference unsupported by RE2J
+
+        assertThrows(ValidationException.class, () -> Regex.compile(pattern));
+        // and not the rej2 PatternSyntaxException
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void queryParserThrowsSelectorExceptionOnMalformedRegex(boolean useRe2j) {
+        Regex.wantsRe2j(useRe2j);
+        String query = "[attr~=(unclosed]";
+
+        boolean threw = false;
+        try {
+            QueryParser.parse(query);
+        } catch (Selector.SelectorParseException e) {
+            threw = true;
+            assertTrue(e.getMessage().contains("Pattern syntax error"));
+        }
+        assertTrue(threw);
+    }
+}

--- a/src/test/java/org/jsoup/nodes/ElementTest.java
+++ b/src/test/java/org/jsoup/nodes/ElementTest.java
@@ -2845,7 +2845,7 @@ public class ElementTest {
         Document doc = Jsoup.parse(reference);
         Throwable ex = assertThrows(IllegalArgumentException.class,
             () -> doc.getElementsByAttributeValueMatching("key", "\\x"));
-        assertEquals("Pattern syntax error: \\x", ex.getMessage());
+        assertTrue(ex.getMessage().contains("Pattern syntax error"));
     }
 
     @Test void getElementsByIndexEquals() {
@@ -2875,7 +2875,7 @@ public class ElementTest {
         Document doc = Jsoup.parse(reference);
         Throwable ex = assertThrows(IllegalArgumentException.class,
             () -> doc.getElementsMatchingText("\\x"));
-        assertEquals("Pattern syntax error: \\x", ex.getMessage());
+        assertTrue(ex.getMessage().contains("Pattern syntax error:"));
     }
 
     @Test void getElementsMatchingText() {
@@ -2897,7 +2897,7 @@ public class ElementTest {
         Document doc = Jsoup.parse(reference);
         Throwable ex = assertThrows(IllegalArgumentException.class,
             () -> doc.getElementsMatchingOwnText("\\x"));
-        assertEquals("Pattern syntax error: \\x", ex.getMessage());
+        assertTrue(ex.getMessage().contains("Pattern syntax error:"));
     }
 
     @Test void hasText() {

--- a/src/test/java/org/jsoup/select/EvaluatorTest.java
+++ b/src/test/java/org/jsoup/select/EvaluatorTest.java
@@ -1,6 +1,7 @@
 package org.jsoup.select;
 
 import org.jsoup.Jsoup;
+import org.jsoup.helper.Regex;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.junit.jupiter.api.Test;
@@ -253,6 +254,34 @@ public class EvaluatorTest {
     @Test
     public void testMatchesWholeOwnTextToString() {
         Pattern pattern = Pattern.compile("example");
+        Evaluator.MatchesWholeOwnText evaluator = new Evaluator.MatchesWholeOwnText(pattern);
+        assertEquals(":matchesWholeOwnText(example)", evaluator.toString());
+    }
+
+    @Test
+    public void testMatchesToStringRegex() {
+        Regex pattern = Regex.compile("example");
+        Evaluator.Matches evaluator = new Evaluator.Matches(pattern);
+        assertEquals(":matches(example)", evaluator.toString());
+    }
+
+    @Test
+    public void testMatchesOwnToStringRegex() {
+        Regex pattern = Regex.compile("example");
+        Evaluator.MatchesOwn evaluator = new Evaluator.MatchesOwn(pattern);
+        assertEquals(":matchesOwn(example)", evaluator.toString());
+    }
+
+    @Test
+    public void testMatchesWholeTextToStringRegex() {
+        Regex pattern = Regex.compile("example");
+        Evaluator.MatchesWholeText evaluator = new Evaluator.MatchesWholeText(pattern);
+        assertEquals(":matchesWholeText(example)", evaluator.toString());
+    }
+
+    @Test
+    public void testMatchesWholeOwnTextToStringRegex() {
+        Regex pattern = Regex.compile("example");
         Evaluator.MatchesWholeOwnText evaluator = new Evaluator.MatchesWholeOwnText(pattern);
         assertEquals(":matchesWholeOwnText(example)", evaluator.toString());
     }


### PR DESCRIPTION
Added option to use re2j for CSS query regexes

Re2j is a linear-time regex engine. This enables jsoup users to now safely accept arbitrary CSS regex-based queries.